### PR TITLE
Add dateutil and other dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,9 @@ setup(
         'openai',
         'pydantic>=2.0.0',
         'python-dateutil',
+        'confuse',
+        'requests',
+        'beautifulsoup4',
+        'pillow',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
         'spotipy',
         'openai',
         'pydantic>=2.0.0',
+        'python-dateutil',
     ],
 )


### PR DESCRIPTION
Include `python-dateutil`, `confuse`, `requests`, `beautifulsoup4`, and `pillow` in the project dependencies.

Fixes #53