### PR TITLE
Increase API request timeout for track info search

### DIFF
--- a/beetsplug/llm.py
+++ b/beetsplug/llm.py
@@ -56,7 +56,7 @@ def search_track_info(query: str):
     base_url = config["llm"]["search"]["base_url"].get()
 
     try:
-        response = requests.post(base_url, json=payload, timeout=10)
+        response = requests.post(base_url, json=payload, timeout=30)
         logger.debug("API Response: {}", response.json().get("message"))
         if not response.text.strip():
             logger.error("Error: Received empty response from API")

--- a/beetsplug/llm.py
+++ b/beetsplug/llm.py
@@ -56,7 +56,7 @@ def search_track_info(query: str):
     base_url = config["llm"]["search"]["base_url"].get()
 
     try:
-        response = requests.post(base_url, json=payload)
+        response = requests.post(base_url, json=payload, timeout=10)
         logger.debug("API Response: {}", response.json().get("message"))
         if not response.text.strip():
             logger.error("Error: Received empty response from API")


### PR DESCRIPTION
Increase the API request timeout to 30 seconds to enhance the reliability of track info search.