### PR TITLE
Refactor distance calculation and enhance playlist features

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can use config filters to finetune any playlist. You can specify the `genre`
 
 ### Library Sync
 - **Plex Library Sync**: `beet plexsync [-f]` imports all the data from your Plex library inside beets. Use the `-f` flag to force update the entire library with fresh information from Plex.
-- **Recent Sync**: `beet plexsyncrecent` updates the information for tracks listened in the last 7 days.
+- **Recent Sync**: `beet plexsyncrecent [--days N]` updates the information for tracks listened in the last N days (default: 7). For example, `beet plexsyncrecent --days 14` will update tracks played in the last 14 days.
 
 ### Playlist Manipulation
 - **Playlist Manipulation**: `plexplaylistadd` and `plexplaylistremove` add or remove tracks from Plex playlists. Use the `-m` flag to provide the playlist name.

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ You can use config filters to finetune any playlist. You can specify the `genre`
 
 ### Library Sync
 - **Plex Library Sync**: `beet plexsync [-f]` imports all the data from your Plex library inside beets. Use the `-f` flag to force update the entire library with fresh information from Plex.
-- **Recent Sync**: `beet plexsyncrecent [--days N]` updates the information for tracks listened in the last N days (default: 7). For example, `beet plexsyncrecent --days 14` will update tracks played in the last 14 days.
+- **Recent Sync**: `beet plexsyncrecent [--days N]` updates the information for tracks listened in the last N days (default: 7). For example, `beet plexsyncrecent [--days 14]` will update tracks played in the last 14 days.
 
 ### Playlist Manipulation
-- **Playlist Manipulation**: `plexplaylistadd` and `plexplaylistremove` add or remove tracks from Plex playlists. Use the `-m` flag to provide the playlist name.
-- **Playlist Clear**: `beet plexplaylistclear` clears a Plex playlist. Use the `-m` flag to specify the playlist name.
+- **Playlist Manipulation**: `beet plexplaylistadd [-m PLAYLIST] [QUERY]` and `beet plexplaylistremove [-m PLAYLIST] [QUERY]` add or remove tracks from Plex playlists. Use the `-m` flag to provide the playlist name. You can use any [beets query][queries_] as an optional filter.
+- **Playlist Clear**: `beet plexplaylistclear [-m PLAYLIST]` clears a Plex playlist. Use the `-m` flag to specify the playlist name.
 
 ### Playlist Import
-- **Playlist Import**: `beet plexplaylistimport` imports individual playlists from Spotify, Apple Music, Gaana.com, JioSaavn, Youtube, Tidal, M3U8 files, and custom APIs. Use the `-m` flag to specify the playlist name and:
+- **Playlist Import**: `beet plexplaylistimport [-m PLAYLIST] [-u URL]` imports individual playlists from Spotify, Apple Music, Gaana.com, JioSaavn, Youtube, Tidal, M3U8 files, and custom APIs. Use the `-m` flag to specify the playlist name and:
   - For online services: use the `-u` flag to supply the full playlist url
   - For M3U8 files: use the `-u` flag with the file path (relative to beets config directory or absolute path)
   - For custom APIs: configure POST requests in config.yaml (see Configuration section)
@@ -80,18 +80,23 @@ You can use config filters to finetune any playlist. You can specify the `genre`
   - Low-rated tracks that were skipped
   - Import statistics and summary
   - The log file helps you identify which tracks need manual attention
-- **Youtube Search Import**: `beet plexsearchimport` imports playlists based on Youtube search. Use the `-m` flag to specify the playlist name, the `-s` flag for the search query, and the `-l` flag to limit the number of search results.
+- **Youtube Search Import**: `beet plexsearchimport [-m PLAYLIST] [-s SEARCH] [-l LIMIT]` imports playlists based on Youtube search. Use the `-m` flag to specify the playlist name, the `-s` flag for the search query, and the `-l` flag to limit the number of search results.
 
 ### Additional Tools
-- **Plex to Spotify**: `beet plex2spotify` copies a Plex playlist to Spotify. Use the `-m` flag to specify the playlist name.
-- **Playlist to Collection**: `beet plexplaylist2collection` converts a Plex playlist to a collection. Use the `-m` flag to specify the playlist name.
-- **Album Collage**: `beet plexcollage` creates a collage of most played albums. Use the `-i` flag to specify the number of days and `-g` flag to specify the grid size.
+- **Plex to Spotify**: `beet plex2spotify [-m PLAYLIST] [QUERY]` copies a Plex playlist to Spotify. Use the `-m` flag to specify the playlist name.
+
+  You can use [beets queries][queries_] with this command to filter which tracks are sent to Spotify. For example, to add only tracks with a `plex_userrating` greater than 2 to the "Sufiyana" playlist, use:
+
+  ```sh
+  beet plex2spotify -m "Sufiyana" plex_userrating:2..
+  ```
+- **Playlist to Collection**: `beet plexplaylist2collection [-m PLAYLIST]` converts a Plex playlist to a collection. Use the `-m` flag to specify the playlist name.
+- **Album Collage**: `beet plexcollage [-i INTERVAL] [-g GRID]` creates a collage of most played albums. Use the `-i` flag to specify the number of days and `-g` flag to specify the grid size.
 
 ### Manual Import for Failed Tracks
 The plugin creates detailed import logs for each playlist import session. You can manually process failed imports using:
 
-- `beet plex_smartplaylists --import-failed`: Process all import logs and attempt manual matching for failed tracks
-- `beet plex_smartplaylists --import-failed --log-file playlist_name_import.log`: Process a specific log file
+- `beet plex_smartplaylists [--import-failed] [--log-file LOGFILE]`: Process all import logs and attempt manual matching for failed tracks, or process a specific log file.
 
 This is especially useful when:
 - You've added new music to your library and want to retry matching previously failed tracks
@@ -204,40 +209,6 @@ spotify:
       ]
   }
   ```
-
-* `beet plexsync [-f]`: allows you to import all the data from your Plex library inside beets. Run the command `beet plexsync` and it will obtain `guid`, `ratingkey`, `userrating`, `skipcount`, `viewcount`, `lastviewedat`, `lastratedat`, and `plex_updated`. See details about these attributes [here][plaxapi]. By default, `plexsync` will not overwrite information for tracks that are already rated. If you want to overwrite all the details again, use the `-f` flag, i.e., `beet plexsync -f` will force update the entire library with fresh information from Plex. This can be useful if you have made significant changes to your Plex library (e.g., updated ratings).
-
-* `beet plexsyncrecent`: If you have a large library, `beets plexsync -f` can take a long time. To update only the recently updated tracks, use `beet plexsyncrecent` to update the information for tracks listened in the last 7 days.
-
-* `plexplaylistadd` and `plexplaylistremove` to add or remove tracks from Plex playlists. These commands should be used in conjunction with beets [queries][queries_] to provide the desired items. Use the `-m` flag to provide the playlist name to be used.
-
-   * To add all country music tracks with `plex_userrating` greater than 5 in a playlist `Country`, you can use the command `beet plexplaylistadd -m Country genre:"Country" plex_userrating:5..`
-
-   * To remove all tracks that are rated less than 5 from the `Country` playlist, use the command `beet plexplaylistremove -m Country plex_userrating:..5`
-
-* `beet plexplaylistimport`: allows you to import playlists from other online services. Spotify, Apple Music, Gaana.com, JioSaavn, Youtube, Tidal, and M3U8 files are currently supported. Use the `-m` flag to specify the playlist name to be created in Plex and:
-  - For online services: use the `-u` flag to supply the full playlist url
-  - For M3U8 files: use the `-u` flag with the file path (relative to beets config directory or absolute path)
-
-  For example, to import the Global Top-100 Apple Music playlist, use the command `beet plexplaylistimport -m Top-100 -u https://music.apple.com/us/playlist/top-100-global/pl.d25f5d1181894928af76c85c967f8f31`. Similarly, to import the Hot-hits USA playlist from Spotify, use the command `beet plexplaylistimport -m HotHitsUSA -u https://open.spotify.com/playlist/37i9dQZF1DX0kbJZpiYdZl`
-
-  You can also use this function to import the weekly jams and weekly exploration playlists from ListenBrainz into Plex. You will need to install and configure the [Listenbrainz plugin][listenbrainz_plugin_]. To import the ListenBrainz playlists, use the command `beet plexplaylistimport --listenbrainz`.
-
-* `beet plexsearchimport`: allows you to import playlists based on Youtube search (results are returned in descending order of the number of views). Use the `-m` flag to specify the playlist name to be created in Plex, supply the search query with the `-s` flag, and use the `-l` flag to limit the number of search results.
-
-  For example, to import the top-20 songs by Taylor Swift, use the command `beet plexsearchimport -s "Taylor Swift" -l 20 -m "Taylor"`.
-
-* `beet plexplaylistclear`: allows you to clear a Plex playlist. Use the `-m` flag to specify the playlist name to be cleared in Plex.
-
-* `beet plex2spotify`: allows you to copy a Plex playlist to Spotify. Use the `-m` flag to specify the playlist name to be copied to Spotify.
-
-* `beet plexplaylist2collection`: converts a Plex playlist to collection. Use the `-m` flag to specify the playlist name. A collection with the same name will be created.
-
-* `beet plexcollage`: allows you to create a collage of most played albums. You can use the `-i` flag to specify the number of days to be used (default is 7 days) and `-g` flag to specify the grid size (default is 3). So, `beet plexcollage -g 5 -i 7` can be used to create a 5x5 collage of the most played albums over the last 7 days. You should get a collage.png file in the beet config folder. The output should look something like the following:
-
-<p align="center">
-  <img src="collage.png">
-</p>
 
 ## Advanced
 Plex matching may be less than perfect and it can miss tracks if the tags don't match perfectly. There are few tools you can use to improve searching:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The command will only generate the specified playlists, skipping others in your 
       - Controls maximum play count (configurable via `max_plays`, default 2)
       - Minimum rating for rated tracks to be included (configurable via `min_rating`, default 4)
       - Percentage of playlist to fill with unrated but popular tracks (configurable via `discovery_ratio`, default 30%)
+      - Excludes tracks played recently (configurable via `exclusion_days`)
 
   3. **Imported Playlists**:
       - Import playlists from external services (Spotify, Apple Music, YouTube, etc.) and local M3U8 files
@@ -247,6 +248,7 @@ plexsync:
         max_plays: 2        # Maximum number of plays for tracks to be included
         min_rating: 4       # Minimum rating for rated tracks
         discovery_ratio: 30 # Percentage of unrated tracks (0-100); Higher values = more discovery
+        exclusion_days: 30  # Number of days to exclude recently played tracks
         filters:
           include:
             genres:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,15 @@ A plugin for [beets][beets] to sync with your Plex server.
 - **AI-Generated Playlists**: Use `beet plexsonic -p "YOUR_PROMPT"` to create a playlist based on YOUR_PROMPT. Modify the playlist name using `-m` flag, change the number of tracks requested with `-n` flag, and clear the playlist before adding new songs with `-c` flag.
 
 ### Smart Playlists
-Use `beet plex_smartplaylists` to generate or manage custom playlists in Plex. The plugin currently supports three types of playlists:
+Use `beet plex_smartplaylists [-o ONLY]` to generate or manage custom playlists in Plex. The plugin currently supports three types of playlists:
+
+You can use the `-o` or `--only` option to specify a comma-separated list of playlist IDs to update. This is useful for updating only certain playlists (e.g., just the AI playlists) on a schedule:
+
+```sh
+beet plex_smartplaylists -o daily_discovery,forgotten_gems
+```
+
+The command will only generate the specified playlists, skipping others in your configuration.
 
   1. **Daily Discovery**:
       - Uses tracks you've played in the last 15 days as a base to learn about listening habits (configurable via `history_days`)

--- a/beetsplug/matching.py
+++ b/beetsplug/matching.py
@@ -4,7 +4,10 @@ import re
 from typing import Optional, Tuple
 
 from beets.autotag import hooks
-from beets.autotag.distance import Distance
+try:
+    from beets.autotag.hooks import Distance
+except ImportError:
+    from beets.autotag.distance import Distance
 from beets.library import Item
 from plexapi.audio import Track
 

--- a/beetsplug/matching.py
+++ b/beetsplug/matching.py
@@ -4,6 +4,7 @@ import re
 from typing import Optional, Tuple
 
 from beets.autotag import hooks
+from beets.autotag.distance import Distance
 from beets.library import Item
 from plexapi.audio import Track
 
@@ -61,7 +62,7 @@ def plex_track_distance(
     item: Item,
     plex_track: Track,
     config: Optional[dict] = None
-) -> Tuple[float, hooks.Distance]:
+) -> Tuple[float, Distance]:
     """Calculate distance between a beets Item and Plex Track."""
     # Define base weights that will be adjusted based on available fields
     base_weights = {
@@ -71,7 +72,7 @@ def plex_track_distance(
     }
 
     # Create distance object
-    dist = hooks.Distance()
+    dist = Distance()
 
     # Check which fields are available
     has_title = bool(item.title and item.title.strip())

--- a/beetsplug/plexsync.py
+++ b/beetsplug/plexsync.py
@@ -675,6 +675,14 @@ class PlexSync(BeetsPlugin):
             default=None,
             help="specific log file to process (default: process all logs)",
         )
+        # Add --only option to filter playlists by id
+        plex_smartplaylists_cmd.parser.add_option(
+            "-o",
+            "--only",
+            dest="only",
+            default=None,
+            help="comma-separated list of playlist IDs to update (e.g. daily_discovery,forgotten_gems)",
+        )
 
         def func_plex_smartplaylists(lib, opts, args):
             if opts.import_failed:
@@ -692,6 +700,12 @@ class PlexSync(BeetsPlugin):
                     "No playlists defined in config['plexsync']['playlists']['items']. Skipping."
                 )
                 return
+
+            # If --only is specified, filter playlists by id
+            if opts.only:
+                only_ids = [x.strip() for x in opts.only.split(",") if x.strip()]
+                playlists_config = [p for p in playlists_config if p.get("id") in only_ids]
+                self._log.info("Filtered playlists to process: {}", only_ids)
 
             # Process all playlists at once
             self._plex_smartplaylists(lib, playlists_config)

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,8 @@ setup(
         'agno>=1.2.16',
         'tavily-python',
         'exa_py',
+        'scipy',
+        'numpy',
+        'pytz',
     ],
 )


### PR DESCRIPTION
1. Refactor the distance calculation in `plex_track_distance` to utilize the `Distance` class from `beets.autotag.distance`, while handling import errors gracefully. 
2. Add missing dependencies to `setup.py` and update the README for clarity on the usage of the recent sync command and playlist manipulation. 
3. Introduce an `--only` option to filter playlists by ID in `PlexSync` and document the exclusion of recently played tracks in playlist configuration.