### PR TITLE
Enhance Plex to Spotify integration with query filtering and improved track search

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ You can use config filters to finetune any playlist. You can specify the `genre`
   ```sh
   beet plex2spotify -m "Sufiyana" plex_userrating:2..
   ```
+
+  Additional filtering examples:
+  - Only transfer highly-rated tracks: `beet plex2spotify -m "My Playlist" plex_userrating:8..`
+  - Transfer tracks by specific artist: `beet plex2spotify -m "Rock Hits" artist:"The Beatles"`
+  - Transfer tracks from a specific year range: `beet plex2spotify -m "2000s Hits" year:2000..2009`
+  - Combine multiple filters: `beet plex2spotify -m "Recent Favorites" plex_userrating:7.. year:2020..`
 - **Playlist to Collection**: `beet plexplaylist2collection [-m PLAYLIST]` converts a Plex playlist to a collection. Use the `-m` flag to specify the playlist name.
 - **Album Collage**: `beet plexcollage [-i INTERVAL] [-g GRID]` creates a collage of most played albums. Use the `-i` flag to specify the number of days and `-g` flag to specify the grid size.
 
@@ -305,6 +311,7 @@ plexsync:
         manual_search: no
         clear_playlist: no
 ```
+
 [collage]: collage.png
 [queries_]: https://beets.readthedocs.io/en/latest/reference/query.html?highlight=queries
 [plaxapi]: https://python-plexapi.readthedocs.io/en/latest/modules/audio.html

--- a/beetsplug/plexsync.py
+++ b/beetsplug/plexsync.py
@@ -2088,30 +2088,36 @@ class PlexSync(BeetsPlugin):
 
             self._log.debug("Beets item: {}", beets_item)
 
+            spotify_track_id = None
+
+            # First try to get existing spotify track ID from beets
             try:
                 spotify_track_id = beets_item.spotify_track_id
                 self._log.debug("Spotify track id in beets: {}", spotify_track_id)
+
+                # Verify the track is available on Spotify
+                if spotify_track_id:
+                    try:
+                        track_info = self.sp.track(spotify_track_id)
+                        if not track_info.get('is_playable', True):
+                            self._log.debug("Track {} is not playable, searching for alternatives", spotify_track_id)
+                            spotify_track_id = None
+                    except Exception as e:
+                        self._log.debug("Error checking track availability {}: {}", spotify_track_id, e)
+                        spotify_track_id = None
+
             except Exception:
                 spotify_track_id = None
                 self._log.debug("Spotify track_id not found in beets")
 
+            # If no valid track ID, search for it
             if not spotify_track_id:
-                self._log.debug(
-                    "Searching for {} {} in Spotify",
-                    beets_item.title,
-                    beets_item.album
-                )
-                spotify_search_results = self.sp.search(
-                    q=f"track:{beets_item.title} album:{beets_item.album}",
-                    limit=1,
-                    type="track",
-                )
-                if not spotify_search_results["tracks"]["items"]:
-                    self._log.info("Spotify match not found for {}", beets_item)
-                    continue
-                spotify_track_id = spotify_search_results["tracks"]["items"][0]["id"]
+                spotify_track_id = self._search_spotify_track(beets_item)
 
-            spotify_tracks.append(spotify_track_id)
+            if spotify_track_id:
+                spotify_tracks.append(spotify_track_id)
+            else:
+                self._log.info("No playable Spotify match found for {}", beets_item)
 
         if query_args:
             self._log.info("Found {} Spotify tracks matching query in Plex playlist order", len(spotify_tracks))
@@ -2119,6 +2125,74 @@ class PlexSync(BeetsPlugin):
             self._log.debug("Found {} Spotify tracks in Plex playlist order", len(spotify_tracks))
 
         self.add_tracks_to_spotify_playlist(playlist, spotify_tracks)
+
+    def _search_spotify_track(self, beets_item):
+        """Search for a track on Spotify with fallback strategies."""
+        search_strategies = [
+            # Strategy 1: Exact search with album
+            lambda: f"track:{beets_item.title} album:{beets_item.album} artist:{beets_item.artist}",
+            # Strategy 2: Title and artist with album
+            lambda: f"track:{beets_item.title} album:{beets_item.album}",
+            # Strategy 3: Just title and artist
+            lambda: f"track:{beets_item.title} artist:{beets_item.artist}",
+            # Strategy 4: Title and artist without track/artist prefixes
+            lambda: f'"{beets_item.title}" "{beets_item.artist}"',
+            # Strategy 5: Just title with artist name
+            lambda: f"{beets_item.title} {beets_item.artist}",
+            # Strategy 6: Very broad search - just title
+            lambda: f"{beets_item.title}"
+        ]
+
+        for i, strategy in enumerate(search_strategies, 1):
+            try:
+                query = strategy()
+                self._log.debug("Spotify search strategy {}: {}", i, query)
+
+                spotify_search_results = self.sp.search(
+                    q=query,
+                    limit=10,  # Get more results to find playable ones
+                    type="track",
+                )
+
+                if spotify_search_results["tracks"]["items"]:
+                    # Look for the best playable match
+                    for track in spotify_search_results["tracks"]["items"]:
+                        if track.get('is_playable', True):
+                            # Basic matching to ensure it's reasonable
+                            track_title = track['name'].lower()
+                            original_title = beets_item.title.lower()
+                            track_artist = track['artists'][0]['name'].lower()
+                            original_artist = beets_item.artist.lower()
+
+                            # Simple similarity check - if title or artist matches reasonably well
+                            title_match = (original_title in track_title or
+                                         track_title in original_title or
+                                         self.get_fuzzy_score(original_title, track_title) > 0.6)
+                            artist_match = (original_artist in track_artist or
+                                          track_artist in original_artist or
+                                          self.get_fuzzy_score(original_artist, track_artist) > 0.6)
+
+                            if title_match and artist_match:
+                                self._log.debug("Found playable match: {} - {} (strategy {})",
+                                               track['name'], track['artists'][0]['name'], i)
+                                return track['id']
+                            elif i >= 5:  # For broader searches, be less strict
+                                if title_match or artist_match:
+                                    self._log.debug("Found loose match: {} - {} (strategy {})",
+                                                   track['name'], track['artists'][0]['name'], i)
+                                    return track['id']
+
+                    # If no good matches found but we have results, log it
+                    self._log.debug("Found {} results but no good matches for strategy {}",
+                                   len(spotify_search_results["tracks"]["items"]), i)
+                else:
+                    self._log.debug("No results for strategy {}", i)
+
+            except Exception as e:
+                self._log.debug("Error in search strategy {}: {}", i, e)
+                continue
+
+        return None
 
     def add_tracks_to_spotify_playlist(self, playlist_name, track_uris):
         """Add tracks to a Spotify playlist."""
@@ -2960,7 +3034,7 @@ class PlexSync(BeetsPlugin):
             except Exception as e:
                 self._log.debug("Error converting track {}: {}", track.title, e)
 
-        self._log.debug("Converted {} tracks to beets items", len(final_tracks))
+        self._log.debug("Found {} tracks matching all criteria", len(final_tracks))
 
         # Split tracks into rated and unrated
         rated_tracks = []

--- a/beetsplug/plexsync.py
+++ b/beetsplug/plexsync.py
@@ -2145,8 +2145,6 @@ class PlexSync(BeetsPlugin):
             lambda: f'"{beets_item.title}" "{beets_item.artist}"',
             # Strategy 5: Just title with artist name
             lambda: f"{beets_item.title} {beets_item.artist}",
-            # Strategy 6: Very broad search - just title
-            lambda: f"{beets_item.title}"
         ]
 
         for i, strategy in enumerate(search_strategies, 1):


### PR DESCRIPTION
1. Introduce optional query filtering for Plex playlists during transfer to Spotify
2. Enhance track search with multiple fallback strategies and ensuring track availability checks for playable content. 
3. Update README with additional filtering examples. 