### PR TITLE
Add placeholder methods for album and item candidates in PlexSync

### DIFF
--- a/beetsplug/plexsync.py
+++ b/beetsplug/plexsync.py
@@ -1272,3 +1272,11 @@ class PlexSync(BeetsPlugin):
         """Metadata plugin interface method - PlexSync doesn't provide track distance."""
         return Distance()
 
+    def candidates(self, album, artist, album_name, threshold):
+        """Metadata plugin interface method - PlexSync doesn't provide album candidates."""
+        return []
+
+    def item_candidates(self, item, threshold):
+        """Metadata plugin interface method - PlexSync doesn't provide item candidates."""
+        return []
+


### PR DESCRIPTION
Introduce placeholder methods for album and item candidates to align with the metadata plugin interface, as PlexSync currently lacks these implementations.

Fixes #113